### PR TITLE
Updates bower to the latest version

### DIFF
--- a/grunt/Dockerfile
+++ b/grunt/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:5.9
 MAINTAINER "Sascha Marcel Schmidt" <docker@saschaschmidt.net>
 
-RUN apt-get update && apt-get install ruby locales -y --no-install-recommends && rm -r /var/lib/apt/lists/*
+RUN apt-get update && apt-get install ruby ruby-dev locales libssl-dev -y --no-install-recommends && rm -r /var/lib/apt/lists/*
 # Configure timezone and locale
 RUN echo "Europe/Berlin" > /etc/timezone && \
     dpkg-reconfigure -f noninteractive tzdata && \

--- a/grunt/package.json
+++ b/grunt/package.json
@@ -19,6 +19,6 @@
         "grunt-modernizr": "1.0.2",
         "grunt-inline-css": "0.1.4",
         "grunt-chmod": "1.1.1",
-        "bower": "^1.4.1"
+        "bower": "^1.8.4"
     }
 }


### PR DESCRIPTION
We get an error message from the Bower repository stating that the version used is too old and not supported anymore. This PR updates Bower to the latest version available. Changes are tested against the Bower's production repository and work as intended.